### PR TITLE
Experiment: enable graph submissions for dependabot 

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,18 @@
+name: Update Dependency Graph
+
+on:
+  push:
+    branches:
+      - main # default branch of the project
+
+jobs:
+  update-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          ## Optional: Define the working directory of your build.
+          ## It should contain the build.sbt file.
+          working-directory: './'


### PR DESCRIPTION
> #### Scala Steward vs Dependabot
> [Scala Steward](https://github.com/scala-steward-org/scala-steward) is a tool that helps you keep the dependencies of your project up-to-date by opening pull requests on GitHub (and other hosting services). It is used in more than a thousand open-source repositories and many proprietary ones and contributes to a large extent to the security of the Scala ecosystem.
> 
> Dependabot and Scala Steward can be used as complementary tools. Scala Steward, as a preventive tool, can help you keep your dependencies up-to-date, which reduces the risk of security vulnerabilities. Dependabot, as a monitoring tool, can notify you when a vulnerability is found, so that you can act quickly.
> 
> Dependabot can also send PRs to update dependencies, but in static configuration files only. It can update the actions in your GitHub workflows, or the Maven dependencies in your POM files, but not the dependencies in the `build.sbt` or `build.sc` files.

from: https://www.scala-lang.org/blog/2022/07/18/secure-your-dependencies-on-github.html