### PR TITLE
Collect coverage and upload to coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 # Scala CircleCI 2.0 configuration file
 # See: https://circleci.com/docs/2.0/sample-config/
-version: 2
+version: 2.1
+
+orbs:
+  coveralls: coveralls/coveralls@2.1.0
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
@@ -45,3 +48,6 @@ jobs:
 
       # run tests!
       - run: cat /dev/null | sbt test:test
+      # collect the coverage and upload to coveralls
+      - run: cat /dev/null | sbt coverage test coverageReport
+      - coveralls/upload

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ val CirceVersion = "0.14.5"
 
 lazy val root = project
   .in(file("."))
+  .enablePlugins(ScoverageSbtPlugin)
   .settings(
     name := "dif",
     version := "0.1.0-SNAPSHOT",
-
     scalaVersion := scala3Version,
 
     libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")


### PR DESCRIPTION
flow:
 1. circle ci picks up a change
 2.  as part of the build process, sbt plugin generates the coverage
 3.  results are uploaded to coveralls https://coveralls.io/github/lazyval/dif
 
**alternative** setup is to use coveralls **github action**:
- 👍 off circle-ci run (agnostic, runs in parallel)
- 👍 gives a preview on how change affected coverage
- 👎 comments from coveralls can be noisy

⚠️ had to alter circle-ci config to allow coverall orb, not secure for shady third-party orbs